### PR TITLE
feat(model): add cable metadata and document model

### DIFF
--- a/common/src/main/scala/model/Document.scala
+++ b/common/src/main/scala/model/Document.scala
@@ -5,34 +5,34 @@
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package divid
+package model
 
-import com.typesafe.sbt.SbtScalariform.scalariformSettings
-import sbt.Keys._
-import sbt._
+import java.time.LocalDateTime
 
+import scala.collection.immutable
 
-object DividBuild extends Build {
-
-	lazy val commonSettings = scalariformSettings ++ Dependencies.Versions ++ Seq(
-		version := "0.0.1-SNAPSHOT",
-		organization := "de.tudarmstadt.lt"
-	)
-
-	// Run all tasks on both projects
-	lazy val root = project.in(file(".")).aggregate(core, common)
-	// Will put common project on the classpath of core
-	lazy val core = project.dependsOn(common).settings(commonSettings: _*)
-	// Name is used to reference folder and project at the command line
-	lazy val common = project.settings(commonSettings: _*)
-}
+/**
+ * Common document representation
+ *
+ * @param id unique document identifier
+ * @param content document body that contains raw text
+ * @param created creation date of the document
+ * @param metadata returns a maybe empty map that maps from keys to a tuple (x, y), where x refers to
+ * the type of the meta data associated wih that key and y represents the respective list of meta data values.
+ */
+case class Document(
+  val id: Int,
+  val content: String,
+  val created: LocalDateTime,
+  val metadata: immutable.Map[String, (String, List[String])]
+)

--- a/common/src/test/scala/model/DocumentTest.scala
+++ b/common/src/test/scala/model/DocumentTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015  Language Technology Group
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package model
+
+import java.time.LocalDateTime
+
+import scala.collection.immutable
+
+import testFactories.FlatSpecWithCommonTraits
+
+class DocumentTest extends FlatSpecWithCommonTraits {
+
+  val metadata = immutable.Map(
+    "Subject" -> ("Text", List("Subject of the document")),
+    "Tags" -> ("Text", List("EFIS", "PBTS", "AR"))
+  )
+
+  val uut = Document(2, "This is a sample \n 12%&/", LocalDateTime.parse("2007-12-03T10:15:30"), metadata)
+
+  behavior of "Document"
+
+  it should "has correct id" in {
+    assert(uut.id == 2)
+  }
+
+  it should "has correct content" in {
+    assert(uut.content == "This is a sample \n 12%&/")
+  }
+
+  it should "has correct datetime" in {
+    assert(uut.created == LocalDateTime.parse("2007-12-03T10:15:30"))
+  }
+
+  it should "contain correct number of metadata" in {
+    assert(uut.metadata.size == 2)
+  }
+}

--- a/common/src/test/scala/testFactories/FlatSpecWithCommonTraits.scala
+++ b/common/src/test/scala/testFactories/FlatSpecWithCommonTraits.scala
@@ -5,34 +5,19 @@
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package divid
+package testFactories
 
-import com.typesafe.sbt.SbtScalariform.scalariformSettings
-import sbt.Keys._
-import sbt._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{Matchers, FlatSpec}
 
-
-object DividBuild extends Build {
-
-	lazy val commonSettings = scalariformSettings ++ Dependencies.Versions ++ Seq(
-		version := "0.0.1-SNAPSHOT",
-		organization := "de.tudarmstadt.lt"
-	)
-
-	// Run all tasks on both projects
-	lazy val root = project.in(file(".")).aggregate(core, common)
-	// Will put common project on the classpath of core
-	lazy val core = project.dependsOn(common).settings(commonSettings: _*)
-	// Name is used to reference folder and project at the command line
-	lazy val common = project.settings(commonSettings: _*)
-}
+trait FlatSpecWithCommonTraits extends FlatSpec with Matchers with MockFactory

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2015  Language Technology Group
  *
  * This program is free software: you can redistribute it and/or modify
@@ -24,34 +24,34 @@ object Dependencies {
 
   val Versions = Seq(
       scalaVersion := "2.11.7"
-      //scalaTestVersion := ...
+      // scalaTestVersion := ...
   )
 
 
   object Compile {
     // Compile
 
-    val config   = "com.typesafe" % "config" % "1.3.0"          			        //ApacheV2
-	  val logging  = "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"  //ApacheV2
-	  val logback	 = "ch.qos.logback" % "logback-classic" % "1.1.3"			        //EPL 1.0 / LGPL 2.1
-    val scopt    = "com.github.scopt" %% "scopt" % "3.3.0"      			        //MIT
-    val playJson = "com.typesafe.play" %% "play-json" % "2.4.3" 			        //ApacheV2
+    val config   = "com.typesafe" % "config" % "1.3.0"                        // ApacheV2
+    val logging  = "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"  // ApacheV2
+    val logback	 = "ch.qos.logback" % "logback-classic" % "1.1.3"             // EPL 1.0 / LGPL 2.1
+    val scopt    = "com.github.scopt" %% "scopt" % "3.3.0"                    // MIT
+    val playJson = "com.typesafe.play" %% "play-json" % "2.4.3"               // ApacheV2
 
-    val jungApi     = "net.sf.jung" % "jung-api" % "2.0.1"           //BSD
-    val jungGraph   = "net.sf.jung" % "jung-graph-impl" % "2.0.1"    //BSD
-    val jungAlgo    = "net.sf.jung" % "jung-algorithms" % "2.0.1"    //BSD
+    val jungApi     = "net.sf.jung" % "jung-api" % "2.0.1"           // BSD
+    val jungGraph   = "net.sf.jung" % "jung-graph-impl" % "2.0.1"    // BSD
+    val jungAlgo    = "net.sf.jung" % "jung-algorithms" % "2.0.1"    // BSD
 
-    val mysql         = "mysql" % "mysql-connector-java" % "5.1.37"  //GPL
-    val hikari        = "com.zaxxer" % "HikariCP" % "2.4.2"          //ApacheV2
-    val h2database    = "com.h2database" % "h2" % "1.4.190"          //MPLV2 / EPL 1.0
-    val scalalikejdbc = "org.scalikejdbc" %% "scalikejdbc" % "2.2.+" //ApacheV2
+    val mysql         = "mysql" % "mysql-connector-java" % "5.1.37"  // GPL
+    val hikari        = "com.zaxxer" % "HikariCP" % "2.4.2"          // ApacheV2
+    val h2database    = "com.h2database" % "h2" % "1.4.190"          // MPLV2 / EPL 1.0
+    val scalalikejdbc = "org.scalikejdbc" %% "scalikejdbc" % "2.2.+" // ApacheV2
 
 
     object Test {
-      val scalalikejdbc = "org.scalikejdbc" %% "scalikejdbc-test" % "2.2.+" % "test"          //ApacheV2
-      val scalatest     = "org.scalatest" %% "scalatest" % "2.2.5" % "test"                   //ApacheV2
-      val scalamock     = "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test" //BSD
-	}
+      val scalalikejdbc = "org.scalikejdbc" %% "scalikejdbc-test" % "2.2.+" % "test"          // ApacheV2
+      val scalatest     = "org.scalatest" %% "scalatest" % "2.2.5" % "test"                   // ApacheV2
+      val scalamock     = "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test" // BSD
+    }
   }
 
   import Compile._

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -49,7 +49,7 @@ http://www.scalastyle.org/rules-0.7.0.html
 
  <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
   <parameters>
-   <parameter name="header"><![CDATA[/* 
+   <parameter name="header"><![CDATA[/*
  * Copyright (C) 2015  Language Technology Group
  *
  * This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
This pull requests adds a basic general and generic document model.
