### PR TITLE
feat(ner): add english ner tagger

### DIFF
--- a/common/src/main/scala/model/Entity.scala
+++ b/common/src/main/scala/model/Entity.scala
@@ -17,22 +17,12 @@
 
 package model
 
-import java.time.LocalDateTime
-
-import scala.collection.immutable
-
 /**
- * Common document representation.
- *
- * @param id unique document identifier.
- * @param content document body that contains raw text.
- * @param created creation date of the document.
- * @param metadata returns a maybe empty map that maps from keys to a tuple (x, y), where x refers to
- * the type of the meta data associated wih that key and y represents the respective list of meta data values.
+ * Entity type (<tt>Person</tt>, <tt>Organisation</tt>, <tt>Location</tt>).
  */
-case class Document(
-  val id: Int,
-  val content: String,
-  val created: LocalDateTime,
-  val metadata: immutable.Map[String, (String, List[String])]
-)
+object EntityType extends Enumeration {
+  val Person = Value
+  val Organization = Value
+  val Location = Value
+}
+

--- a/common/src/main/scala/utils/Benchmark.scala
+++ b/common/src/main/scala/utils/Benchmark.scala
@@ -19,7 +19,7 @@ package utils
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.slf4j.LazyLogging
 
 import scala.language.implicitConversions
 

--- a/common/src/main/scala/utils/io/IoUtils.scala
+++ b/common/src/main/scala/utils/io/IoUtils.scala
@@ -19,7 +19,7 @@ package utils.io
 
 import java.nio.file.Path
 
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.slf4j.LazyLogging
 
 import scala.io.Source
 

--- a/common/src/main/scala/utils/nlp/EnglishNLPUtils.scala
+++ b/common/src/main/scala/utils/nlp/EnglishNLPUtils.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015  Language Technology Group
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils.nlp
+
+import epic.preprocess.{TreebankTokenizer, MLSentenceSegmenter}
+
+/**
+ * Common utility functions to process english text.
+ */
+class EnglishNLPUtils {
+
+  private val sentenceSplitter = MLSentenceSegmenter.bundled().get
+  private val tokenizer = new TreebankTokenizer()
+
+  /**
+   * Segments a given text into sentences using ScalaNLP's [[MLSentenceSegmenter]]. Removes also
+   * new lines from the segmented sentences.
+   *
+   * @param text text to be segmented.
+   * @return [[IndexedSeq]] with segmented sentences.
+   */
+  def segmentText(text: String): IndexedSeq[String] = sentenceSplitter(text).map(_.replaceAll("\n", " ").trim)
+
+  /**
+   * Tokenizes a given text into token using ScalaNLP's [[TreebankTokenizer]].
+   *
+   * @param text text to be tokenized.
+   * @return [[IndexedSeq]] with token.
+   */
+  def tokenize(text: String): IndexedSeq[String] = tokenizer(text)
+}

--- a/common/src/test/scala/utils/BenchmarkTest.scala
+++ b/common/src/test/scala/utils/BenchmarkTest.scala
@@ -17,7 +17,7 @@
 
 package utils
 
-import com.typesafe.scalalogging.Logger
+import com.typesafe.scalalogging.slf4j.Logger
 import org.slf4j.{Logger => Underlying}
 import testFactories.FlatSpecWithCommonTraits
 

--- a/common/src/test/scala/utils/nlp/EnglishNLPUtilsTest.scala
+++ b/common/src/test/scala/utils/nlp/EnglishNLPUtilsTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015  Language Technology Group
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils.nlp
+
+import testFactories.FlatSpecWithCommonTraits
+
+class EnglishNLPUtilsTest extends FlatSpecWithCommonTraits {
+
+  // We won't test the tokenize method, because it doesn't add any further
+  // functions and is already tested by ScalaNLP.
+  val uut = new EnglishNLPUtils()
+
+  "segmentation" should "split multiple sentences at sentence boundaries" in {
+    val s1 = "Always code as if the guy who ends up maintaining your code will be a violent psychopath who knows where you live!"
+    val s2 = "Deleted code is debugged code."
+    val s3 = "Is this a question?"
+    val s4 = "The end."
+
+    val expected = Vector(s1, s2, s3, s4)
+    val text = expected.mkString(" ")
+
+    val actual = uut.segmentText(text)
+
+    assert(expected == actual)
+  }
+
+  "segmentation" should "remove newlines and trim source text" in {
+    val text =
+      """ First line
+          second line?
+
+
+          last line.
+      """
+
+    val expected = Vector("First line           second line?", "last line.")
+    val actual = uut.segmentText(text)
+
+    assert(expected == actual)
+  }
+}

--- a/core/src/main/scala/Run.scala
+++ b/core/src/main/scala/Run.scala
@@ -17,14 +17,19 @@
 
 import java.nio.file.Paths
 
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.slf4j.LazyLogging
 import reader.CSVCorpusReader
 import scopt.OptionParser
 
+/**
+ * Used to parse command line arguments.
+ *
+ * @param sourcefile corpus file to be processed.
+ */
 case class ArgumentOptions(sourcefile: String = "")
 
 /**
- * Contains the main method to start the processing.
+ * Contains the main method to start the processing pipeline.
  */
 object Run extends LazyLogging {
 
@@ -41,12 +46,12 @@ object Run extends LazyLogging {
   private def createOptionParser(): OptionParser[ArgumentOptions] = {
     new OptionParser[ArgumentOptions]("DIVID-DJ") {
       head("DIVID-DJ", "0.1.0-SNAPSHOT")
-      help("help") text "prints this usage text."
-      version("version") text "Version 0.1.0-SNAPSHOT"
+      help("help").text("prints this usage text.")
+      version("version").text("Version 0.1.0-SNAPSHOT")
 
-      opt[String]("sourceFile") required () action { (x, c) =>
+      opt[String]("sourceFile").required().action { (x, c) =>
         c.copy(sourcefile = x)
-      } text """[required] Path, where the input csv file is located."""
+      }.text("[required] Path, where the input csv file is located.")
     }
   }
 }

--- a/core/src/main/scala/ie/ner/EnglishEntityExtractor.scala
+++ b/core/src/main/scala/ie/ner/EnglishEntityExtractor.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015  Language Technology Group
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ie.ner
+
+import epic.trees.Span
+import model.EntityType
+import utils.nlp.EnglishNLPUtils
+
+import scala.collection.immutable
+
+/**
+ * Named Entity tagger based on ScalaNLP CRF NER tagger. The supplied model supports three different
+ * classes: <tt>Person</tt>, <tt>Organization</tt> and <tt>Location<tt>. Longer passages will be segmented
+ * to sentences and additionally annotated with token annotations before the tagger is applied. Segmentation
+ * and tokenization capability is served by `nlpUtils`.
+ *
+ * @param nlpUtils serves segmentation and tokenization capabilities.
+ */
+class EnglishEntityExtractor(nlpUtils: EnglishNLPUtils = new EnglishNLPUtils) extends NamedEntityExtractor {
+
+  private val ner = epic.models.NerSelector.loadNer("en").get
+  private val labelToEntityType = immutable.Map(
+    "PER" -> EntityType.Person,
+    "ORG" -> EntityType.Organization,
+    "LOC" -> EntityType.Location
+  )
+
+  /**
+   * @inheritdoc
+   */
+  override def extractNamedEntities(text: String): List[(String, EntityType.Value)] = {
+    val sentences = nlpUtils.segmentText(text).map(nlpUtils.tokenize).toIndexedSeq
+    val entities = sentences.flatMap(extractFromIndexedSentence)
+
+    entities.toList
+  }
+
+  private def extractFromIndexedSentence(sentence: IndexedSeq[String]): Iterator[(String, EntityType.Value)] = {
+    val segments = ner.bestSequence(sentence)
+
+    val entityTuple = segments.segmentsWithOutside.collect {
+      case (Some(l), span: Span) =>
+        val ne = segments.words.slice(span.begin, span.end).mkString(" ")
+        val label = labelToEntityType(l.toString)
+
+        (ne, label)
+    }
+    entityTuple
+  }
+}

--- a/core/src/main/scala/ie/ner/NamedEntityExtractor.scala
+++ b/core/src/main/scala/ie/ner/NamedEntityExtractor.scala
@@ -15,24 +15,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package model
+package ie.ner
 
-import java.time.LocalDateTime
-
-import scala.collection.immutable
+import model.EntityType
 
 /**
- * Common document representation.
- *
- * @param id unique document identifier.
- * @param content document body that contains raw text.
- * @param created creation date of the document.
- * @param metadata returns a maybe empty map that maps from keys to a tuple (x, y), where x refers to
- * the type of the meta data associated wih that key and y represents the respective list of meta data values.
+ * Common trait for different named entity extraction algorithms.
  */
-case class Document(
-  val id: Int,
-  val content: String,
-  val created: LocalDateTime,
-  val metadata: immutable.Map[String, (String, List[String])]
-)
+trait NamedEntityExtractor {
+
+  /**
+   * Returns named entities with their types [[EntityType.Value]] from a given text.
+   *
+   * @param text text that should be used to extract named entities from.
+   * @return a list that contains tuple of the following form (named entity name, ne-type).
+   *         If the `text` contains no named entities the list will be empty.
+   */
+  def extractNamedEntities(text: String): List[(String, EntityType.Value)]
+}

--- a/core/src/main/scala/preprocess/TrueCaser.scala
+++ b/core/src/main/scala/preprocess/TrueCaser.scala
@@ -19,7 +19,7 @@ package preprocess
 
 import java.nio.file.Path
 
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.slf4j.LazyLogging
 import model.Document
 import utils.Benchmark.toBenchmarkable
 import utils.RichString.richString

--- a/core/src/main/scala/reader/CSVCorpusReader.scala
+++ b/core/src/main/scala/reader/CSVCorpusReader.scala
@@ -23,7 +23,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 import com.github.tototoshi.csv.CSVReader
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.slf4j.LazyLogging
 import model.Document
 
 import scala.util.control.NonFatal

--- a/core/src/test/scala/ie/ner/EnglishEntityExtractorTest.scala
+++ b/core/src/test/scala/ie/ner/EnglishEntityExtractorTest.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015  Language Technology Group
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ie.ner
+
+import model.EntityType
+import testFactories.FlatSpecWithCommonTraits
+import utils.nlp.{EnglishNLPUtils, EnglishNLPUtilsTest}
+
+class EnglishEntityExtractorTest extends FlatSpecWithCommonTraits {
+
+  it should "assign per label for a person" in {
+    val sentence = "Angela is the german chancellor"
+
+    val uut = whenExtractorIsInitialized(
+      List(sentence),
+      List(
+        List("Angela", "is", "the", "german", "chancellor", ".")
+      )
+    )
+
+    val expected = List(("Angela", EntityType.Person))
+    val actual = uut.extractNamedEntities(sentence)
+
+    assert(expected == actual)
+  }
+
+  it should "assign org label for a organization" in {
+    val sentence = "She is member of CSU."
+
+    val uut = whenExtractorIsInitialized(
+      List(sentence),
+      List(
+        List("She", "is", "member", "of", "CSU", ".")
+      )
+    )
+
+    val expected = List(("CSU", EntityType.Organization))
+    val actual = uut.extractNamedEntities(sentence)
+
+    assert(expected == actual)
+  }
+
+  it should "assign loc label for a location" in {
+    val sentence = "She lives of Berlin."
+
+    val uut = whenExtractorIsInitialized(
+      List(sentence),
+      List(
+        List("She", "lives", "in", "Berlin", ".")
+      )
+    )
+
+    val expected = List(("Berlin", EntityType.Location))
+    val actual = uut.extractNamedEntities(sentence)
+
+    assert(expected == actual)
+  }
+
+  it should "not split multi word expressions" in {
+    val sentence = "Angela Merkel is a woman."
+
+    val uut = whenExtractorIsInitialized(
+      List(sentence),
+      List(
+        List("Angela", "Merkel", "is", "a", "woman", ".")
+      )
+    )
+
+    val expected = List(("Angela Merkel", EntityType.Person))
+    val actual = uut.extractNamedEntities(sentence)
+
+    assert(expected == actual)
+  }
+
+  it should "extract named entities from multiple sentences" in {
+    val s1 = "Angela is the german chancellor."
+    val s2 = "She is member of CSU."
+    val sentences = List(s1, s2)
+
+    val uut = whenExtractorIsInitialized(
+      sentences,
+      List(
+        List("Angela", "is", "the", "german", "chancellor", "."),
+        List("She", "is", "member", "of", "CSU", ".")
+      )
+    )
+
+    val expected = List(("Angela", EntityType.Person), ("CSU", EntityType.Organization))
+    val actual = uut.extractNamedEntities(sentences.mkString(" "))
+
+    assert(expected == actual)
+  }
+
+  def whenExtractorIsInitialized(sentences: List[String], sentenceToken: List[List[String]]): EnglishEntityExtractor = {
+    val nlpUtilsMock = mock[EnglishNLPUtils]
+
+    (nlpUtilsMock.segmentText _).expects(sentences.mkString(" ")).returning(sentences.toIndexedSeq).anyNumberOfTimes()
+    (sentences zip sentenceToken).foreach {
+      case (s, t) =>
+        (nlpUtilsMock.tokenize _).expects(s).returning(t.toIndexedSeq).once()
+    }
+
+    new EnglishEntityExtractor(nlpUtilsMock)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,16 +27,18 @@ object Dependencies {
       // scalaTestVersion := ...
   )
 
-
   object Compile {
     // Compile
 
-    val config   = "com.typesafe" % "config" % "1.3.0"                        // ApacheV2
-    val logging  = "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"  // ApacheV2
-    val logback  = "ch.qos.logback" % "logback-classic" % "1.1.3"             // EPL 1.0 / LGPL 2.1
-    val scopt    = "com.github.scopt" %% "scopt" % "3.3.0"                    // MIT
-    val playJson = "com.typesafe.play" %% "play-json" % "2.4.3"               // ApacheV2
-    val csv      = "com.github.tototoshi" %% "scala-csv" % "1.2.2"            // ApacheV2
+    val config      = "com.typesafe" % "config" % "1.3.0"                             // ApacheV2
+    val logging     = "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2" // ApacheV2
+    val slf4jSimple = "org.slf4j"  %  "slf4j-simple" % "1.7.6"                        // MIT
+    val scopt       = "com.github.scopt" %% "scopt" % "3.3.0"                         // MIT
+    val playJson    = "com.typesafe.play" %% "play-json" % "2.4.3"                    // ApacheV2
+    val csv         = "com.github.tototoshi" %% "scala-csv" % "1.2.2"                 // ApacheV2
+
+    val ner      = "org.scalanlp" %% "epic-ner-en-conll" % "2015.1.25" // ApacheV2
+    val scalaNlp = "org.scalanlp" %% "epic" % "0.3" excludeAll(ExclusionRule(organization = "com.typesafe.scala-logging"))  // ApacheV2
 
     val jungApi     = "net.sf.jung" % "jung-api" % "2.0.1"           // BSD
     val jungGraph   = "net.sf.jung" % "jung-graph-impl" % "2.0.1"    // BSD
@@ -60,10 +62,10 @@ object Dependencies {
   val l = libraryDependencies
 
   // Projects
-  val coreDeps = l ++= Seq(config, scopt, playJson, csv, logging, logback,
-        jungApi, jungGraph, jungAlgo, mysql, hikari, h2database,
+  val coreDeps = l ++= Seq(config, scopt, playJson, csv, logging, slf4jSimple,
+        jungApi, jungGraph, jungAlgo, ner, scalaNlp, mysql, hikari, h2database,
         scalalikejdbc, Test.scalalikejdbc, Test.scalatest, Test.scalamock)
 
-  val commonDeps = l ++= Seq(playJson, jungApi, jungGraph, jungAlgo, mysql, hikari, h2database,
-        logging, logback, scalalikejdbc, Test.scalalikejdbc, Test.scalatest, Test.scalamock)
+  val commonDeps = l ++= Seq(playJson, jungApi, scalaNlp, jungGraph, jungAlgo, mysql, hikari,
+        h2database, logging, slf4jSimple, scalalikejdbc, Test.scalalikejdbc, Test.scalatest, Test.scalamock)
 }


### PR DESCRIPTION
This commit adds an english ner tagger based on ScalaNLP. It also
replaces the classic-logback logging backend with slf4j due to licence 
problems. 
